### PR TITLE
Fix typo in installation instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -64,7 +64,7 @@ If it's not installed, use the `gem` command to install it.
 
  $ gem install bundler
 
-Then, use the `bundle` command to install the project dependencies:
+Then, use the `bundle` command (which is provided by the bundler gem) to install the project dependencies:
 
  $ bundle
 


### PR DESCRIPTION
I think the current "gem install bundler" is a typo